### PR TITLE
updated gazebo elements to support multiples/renaming

### DIFF
--- a/barrett_hand_description/robots/bh_alone.urdf.xacro
+++ b/barrett_hand_description/robots/bh_alone.urdf.xacro
@@ -33,5 +33,13 @@
 		<origin xyz="0 0 0" rpy="0 0 0" />
 	</xacro:bhand_macro>
 	
+	<gazebo>
+	    <plugin name="ros_control" filename="libgazebo_ros_control.so">
+	       <robotNamespace>/</robotNamespace>
+	       <controlPeriod>0.001</controlPeriod>
+	       <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+	    </plugin>
+    </gazebo>
+	
 </robot>
 

--- a/barrett_hand_description/urdf/bh282.gazebo.xacro
+++ b/barrett_hand_description/urdf/bh282.gazebo.xacro
@@ -1,43 +1,35 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="bh_gazebo" params="name">
-	<!-- ros_control plugin -->
-	<gazebo>
-		<plugin name="ros_control" filename="libgazebo_ros_control.so">
-		   <robotNamespace>/</robotNamespace>
-		   <controlPeriod>0.001</controlPeriod>
-		   <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
-		</plugin>
-	</gazebo>
 
 	<gazebo>
 	   	<plugin name="mimic_plugin" filename="libgazebo_mimic_plugin.so">
-       		   <joint>bh_j11_joint</joint>
-       		   <mimicJoint>bh_j21_joint</mimicJoint>
+       		   <joint>${name}_j11_joint</joint>
+       		   <mimicJoint>${name}_j21_joint</mimicJoint>
        		   <multiplier>1</multiplier>
        		</plugin>
         </gazebo> 
 
 	<gazebo>
 	    	<plugin name="mimic_plugin" filename="libgazebo_mimic_plugin.so">
-       		   <joint>bh_j12_joint</joint>
-       		   <mimicJoint>bh_j13_joint</mimicJoint>
+       		   <joint>${name}_j12_joint</joint>
+       		   <mimicJoint>${name}_j13_joint</mimicJoint>
        		   <multiplier>0.344</multiplier>
        		</plugin>
         </gazebo> 
 
 	<gazebo>
 	    	<plugin name="mimic_plugin" filename="libgazebo_mimic_plugin.so">
-       		   <joint>bh_j22_joint</joint>
-       		   <mimicJoint>bh_j23_joint</mimicJoint>
+       		   <joint>${name}_j22_joint</joint>
+       		   <mimicJoint>${name}_j23_joint</mimicJoint>
        		   <multiplier>0.344</multiplier>
        		</plugin>
         </gazebo> 
 
 	<gazebo>
 	    	<plugin name="mimic_plugin" filename="libgazebo_mimic_plugin.so">
-       		   <joint>bh_j32_joint</joint>
-       		   <mimicJoint>bh_j33_joint</mimicJoint>
+       		   <joint>${name}_j32_joint</joint>
+       		   <mimicJoint>${name}_j33_joint</mimicJoint>
        		   <multiplier>0.344</multiplier>
        		</plugin>
         </gazebo> 


### PR DESCRIPTION
-added ${name} param to mimic joint names to match corresponding urdf
-moved control plugin to bh_alone.urdf.xacro so multiple hands can be included into other robots without a name collision in gazebo
